### PR TITLE
Add unit tests for lazy parameter parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,8 @@ lazy val macros = crossProject(JSPlatform, JVMPlatform)
       "org.scala-lang.modules" %%% "scala-xml" % scalaXMLVersion,
       "io.circe" %% "circe-jawn" % circeVersion,
       "io.circe" %% "circe-yaml" % circeYamlVersion,
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "org.scalatest" %%% "scalatest" % scalatestVersion % "test"
     )
   )
   .jsSettings(

--- a/macros/shared/src/test/scala/spec/ProfigLookupPathSpec.scala
+++ b/macros/shared/src/test/scala/spec/ProfigLookupPathSpec.scala
@@ -1,0 +1,29 @@
+package spec
+
+import io.circe.Json
+import org.scalatest.{Matchers, WordSpec}
+import profig.ProfigLookupPath
+
+class ProfigLookupPathSpec extends WordSpec with Matchers {
+  "ProfigLookupPath" should {
+    "extract property name before first equal sign" in {
+      val testProp = "prop_name = prop_value=1"
+      val expectedJson = Json.fromFields(List(
+        ("prop_name", Json.fromString("prop_value=1"))
+      ))
+
+      val parsedProp = ProfigLookupPath.propertiesString2Json(testProp)
+      parsedProp should be(expectedJson)
+    }
+    "extract property name before first colon sign" in {
+      val testProp = "prop_name: prop_value:1"
+      val expectedJson = Json.fromFields(List(
+        ("prop_name", Json.fromString("prop_value:1"))
+      ))
+
+      val parsedProp = ProfigLookupPath.propertiesString2Json(testProp)
+      parsedProp should be(expectedJson)
+
+    }
+  }
+}


### PR DESCRIPTION
Parameter parsing from YAML and properties files is done
using a regular expression that should enforce reading
parameter name before the first seperator, not the last.